### PR TITLE
implement token-based auth

### DIFF
--- a/msg/config.py
+++ b/msg/config.py
@@ -1,3 +1,4 @@
+SECRET_KEY = "honk honk honk honk"
 REDIS_URL = "redis://localhost"
 SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
 SLEEP_RATE = 0.2

--- a/msg/msg.py
+++ b/msg/msg.py
@@ -136,7 +136,7 @@ class User(flask_restful.Resource):
             return new_user.to_dict()
 
 
-class Authentication(flask_restful.Resource):
+class Token(flask_restful.Resource):
     """blah.
 
     """
@@ -183,7 +183,7 @@ class Authentication(flask_restful.Resource):
     @staticmethod
     @auth.verify_password
     def verify_password(username_or_token, password):
-        user = Authentication.verify_auth_token(username_or_token)
+        user = Token.verify_auth_token(username_or_token)
 
         if user is None:
             # try to authenticate with username/password
@@ -361,7 +361,7 @@ def init_db():
     db.session.commit()
 
 
-api.add_resource(Authentication, '/auth')
+api.add_resource(Token, '/token')
 api.add_resource(Message, '/message', '/message/<int:message_id>')
 api.add_resource(Messages, '/messages', '/messages/<int:page>')
 api.add_resource(User, '/user', '/user/<int:user_id>', '/user/<username>')

--- a/msg/msg.py
+++ b/msg/msg.py
@@ -9,6 +9,8 @@ import json
 # 3rd party
 from flask_httpauth import HTTPBasicAuth
 from flask_sse import sse
+from itsdangerous import (TimedJSONWebSignatureSerializer
+                          as Serializer, BadSignature, SignatureExpired)
 
 import flask
 import flask_limiter
@@ -134,6 +136,67 @@ class User(flask_restful.Resource):
             return new_user.to_dict()
 
 
+class Authentication(flask_restful.Resource):
+    """blah.
+
+    """
+
+    # TODO: add limiter
+    @auth.login_required
+    def get(self):
+        token = self.generate_auth_token(flask.g.user.id)
+        return {'token': token.decode('ascii')}
+
+    @staticmethod
+    def generate_auth_token(id_, expiration=600):
+        s = Serializer(app.config['SECRET_KEY'],
+                       expires_in=expiration)
+        return s.dumps({'id': str(id_)})
+
+    @staticmethod
+    def verify_auth_token(token):
+        s = Serializer(app.config['SECRET_KEY'])
+
+        try:
+            data = s.loads(token)
+        except SignatureExpired:
+            return None  # valid token but expired
+        except BadSignature:
+            return None  # invalid token
+
+        user = db.session.query(models.User).get(data['id'])
+        return user
+
+    @staticmethod
+    @auth.login_required
+    def get_auth_token():
+        user_id = flask_login.current_user.id
+        token = Authenticate.generate_auth_token(user_id)
+        return {'token': token.decode('ascii')}
+
+    @staticmethod
+    @auth.error_handler
+    def auth_error():
+        flask_restful.abort(401, message="Unathorized")
+
+    # TODO: update docstring
+    @staticmethod
+    @auth.verify_password
+    def verify_password(username_or_token, password):
+        user = Authentication.verify_auth_token(username_or_token)
+
+        if user is None:
+            # try to authenticate with username/password
+            user = (db.session.query(models.User)
+                    .filter_by(username=username_or_token).first())
+
+            if user is None or (not user.check_password(password)):
+                return False
+
+        flask.g.user = user
+        return True
+
+
 class Messages(flask_restful.Resource):
     """Manage more than one message at a time!
 
@@ -229,9 +292,7 @@ class Message(flask_restful.Resource):
         """
 
         text = get_valid_json(self.SCHEMA)['text']
-        user_id = (db.session.query(models.User)
-                   .filter(models.User.username == auth.username())
-                   .first().id)
+        user_id = flask.g.user.id
         new_message = models.Message(user_id, text)
         db.session.add(new_message)
         db.session.commit()
@@ -277,39 +338,6 @@ class Message(flask_restful.Resource):
             flask_restful.abort(404, message=message)
 
 
-@auth.error_handler
-def auth_error():
-    flask_restful.abort(401, message="Unathorized")
-
-
-@auth.verify_password
-def get_password(username, password):
-    """For HTTPBasicAuth; this simply gets the
-    corresponding user, then return the result
-    of checking that password.
-
-    Arguments:
-        username (str):
-        password (str):
-
-    See Also:
-        flask_httpauth
-
-    Returns:
-        bool: True if the password is correct for the supplied
-            username, False otherwise.
-
-    """
-
-    result = (db.session.query(models.User)
-              .filter(models.User.username == username).first())
-
-    if result is None:
-        return False
-    else:
-        return result.check_password(password)
-
-
 def get_valid_json(schema):
     json_data = flask.request.get_json(force=True)
 
@@ -333,6 +361,7 @@ def init_db():
     db.session.commit()
 
 
+api.add_resource(Authentication, '/auth')
 api.add_resource(Message, '/message', '/message/<int:message_id>')
 api.add_resource(Messages, '/messages', '/messages/<int:page>')
 api.add_resource(User, '/user', '/user/<int:user_id>', '/user/<username>')

--- a/tests/msgboard_test.py
+++ b/tests/msgboard_test.py
@@ -268,6 +268,44 @@ class TestEverything(unittest.TestCase):
 
         assert post_fixture == response
 
+    def test_post_with_token(self, create_user=True):
+        """Test creating a message using token
+        authorization.
+
+        """
+
+        if create_user:
+            self.test_create_user()
+
+        # Generate token, should be it's own function maybe?
+        headers = self.make_base64_header("testuser", "testpass")
+        status, response = self.get('/token', headers=headers)
+
+        assert status == 200
+
+        message_content = {"text": 'I am a message.'}
+        token = response["token"]
+        token_headers = self.make_base64_header(token, "unused")
+        status, response = self.post('/message', headers=token_headers,
+                                     data=message_content)
+
+        assert status == 200
+
+        del response["created"]
+        del response["id"]
+        del response["user"]["created"]
+
+        post_fixture = {
+                        "text": 'I am a message.',
+                        "user": {
+                                 "bio": None,
+                                 "id": 1,
+                                 "username": 'testuser'
+                                }
+                       }
+
+        assert post_fixture == response
+
     # TODO: this test is lame and will only fetch one
     # message through messages.
     def test_get_messages(self):


### PR DESCRIPTION
Add resource Authentication to /auth. A user
will request a token with their base64 creds
(typical HTTPBasicAuth) to /auth. Further,
the username part of the base64 creds should
be the token, whereas the password's value is
completely ignored.

Using application context for user/database
stuff in Authentication.

Some requests need to use this flask.g application
context for user. I'll leave that to QA to find out
hehehehe.
